### PR TITLE
add warning to use CLI for vanity pubkeys

### DIFF
--- a/docs/references/keypairs-and-wallets.md
+++ b/docs/references/keypairs-and-wallets.md
@@ -107,7 +107,7 @@ keypair, you will need to generate one.
 
 @[code](@/code/keypairs-and-wallets/generate-keypair/generate-keypair.preview.en.sh)
 
-  </template>  
+  </template>
 
   </SolanaCodeGroupItem>
 
@@ -181,7 +181,7 @@ to test out your dApp.
 
 @[code](@/code/keypairs-and-wallets/keypair-from-secret/keypair-from-secret.en.sh)
 
-  </template>  
+  </template>
 
   </SolanaCodeGroupItem>
 
@@ -240,7 +240,6 @@ to test out your dApp.
 
 </SolanaCodeGroup>
 
-
 ## How to verify a Keypair
 
 If you are given a keypair, you can verify whether or not the secret
@@ -291,7 +290,7 @@ matches the given public key
 
 @[code](@/code/keypairs-and-wallets/verify-keypair/verify-keypair.en.sh)
 
-  </template>  
+  </template>
 
   </SolanaCodeGroupItem>
 
@@ -346,12 +345,11 @@ If you're creating a wallet, you will need to generate a mnemonic phrase so that
 
 @[code](@/code/keypairs-and-wallets/generate-mnemonic/from-bip39.sh)
 
-  </template>  
+  </template>
 
   </SolanaCodeGroupItem>
 
 </SolanaCodeGroup>
-
 
 ## How to restore a Keypair from a mnemonic phrase
 
@@ -405,7 +403,7 @@ You can convert the mnemonic to Keypairs for local testing.
 
 @[code](@/code/keypairs-and-wallets/mnemonic-to-keypair/from-bip39.sh)
 
-  </template>  
+  </template>
 
   </SolanaCodeGroupItem>
 
@@ -442,7 +440,7 @@ You can convert the mnemonic to Keypairs for local testing.
 
 @[code](@/code/keypairs-and-wallets/mnemonic-to-keypair/from-bip44.sh)
 
-  </template>  
+  </template>
 
   </SolanaCodeGroupItem>
 
@@ -450,13 +448,17 @@ You can convert the mnemonic to Keypairs for local testing.
 
 ## How to generate a vanity address
 
-Vanity publickeys, or custom addresses are keys that have start with 
-specific characters. For example, a person may want a publickey to 
-start with "elv1s", or maybe even "cook". These can help other people 
+Vanity publickeys, or custom addresses are keys that have start with
+specific characters. For example, a person may want a publickey to
+start with "elv1s", or maybe even "cook". These can help other people
 remember who the key belongs to, making the key more easily identifiable.
 
 Note: The more characters in your vanity address, the longer it will
 take.
+
+::: warning
+You should just use the CLI for this task. The Python and TypeScript examples are for illustrative purposes and are much slower than the CLI.
+:::
 
 <SolanaCodeGroup>
    <SolanaCodeGroupItem title="TS" active>
@@ -503,7 +505,7 @@ take.
 
 @[code](@/code/keypairs-and-wallets/vanity-publickeys/vanity-publickeys.en.sh)
 
-  </template>  
+  </template>
 
   </SolanaCodeGroupItem>
 
@@ -512,7 +514,7 @@ take.
 ## How to sign and verify messages with wallets
 
 The primary function of a keypair is to sign messages and enable
-verification of the signature. Verification of a signature allows 
+verification of the signature. Verification of a signature allows
 the recipient to be sure that the data was signed by the owner of a
 specific private key.
 


### PR DESCRIPTION
The only thing I actually added here was the `::: warning` bit, the rest is just VS Code autoformatting some whitespace 🤷‍♂️