### PR TITLE
feat: Token transaction w/ partial sign snippet (#293)

### DIFF
--- a/code/offline-transactions/partial-sign/main.en.ts
+++ b/code/offline-transactions/partial-sign/main.en.ts
@@ -1,0 +1,71 @@
+import { createTransferCheckedInstruction, getAssociatedTokenAddress, getMint, getOrCreateAssociatedTokenAccount } from "@solana/spl-token";
+import { clusterApiUrl, Connection, Keypair, LAMPORTS_PER_SOL, PublicKey, SystemProgram, Transaction } from "@solana/web3.js";
+import base58 from "bs58";
+
+/* The transaction:
+  * - sends 0.01 SOL from Alice to Bob
+  * - sends 1 token from Bob to Alice
+  * - is partially signed by Bob, so Alice can approve + send it
+*/
+
+(async () => {
+  const connection = new Connection(clusterApiUrl("devnet"), "confirmed");
+
+  const alicePublicKey = new PublicKey("5YNmS1R9nNSCDzb5a7mMJ1dwK9uHeAAF4CmPEwKgVWr8");
+  const bobKeypair = Keypair.fromSecretKey(
+    base58.decode("4NMwxzmYj2uvHuq8xoqhY8RXg63KSVJM1DXkpbmkUY7YQWuoyQgFnnzn6yo3CMnqZasnNPNuAT2TLwQsCaKkUddp")
+  );
+  const tokenAddress = new PublicKey("Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr");
+  const bobTokenAddress = await getAssociatedTokenAddress(tokenAddress, bobKeypair.publicKey);
+
+  // Alice may not have a token account, so Bob creates one if not
+  const aliceTokenAccount = await getOrCreateAssociatedTokenAccount(
+    connection,
+    bobKeypair, // Bob pays the fee to create it
+    tokenAddress, // which token the account is for
+    alicePublicKey, // who the token account is for
+  );
+
+  // Get the details about the token mint
+  const tokenMint = await getMint(connection, tokenAddress);
+
+  // Get a recent blockhash to include in the transaction
+  const { blockhash } = await connection.getLatestBlockhash("finalized");
+
+  const transaction = new Transaction({
+    recentBlockhash: blockhash,
+    // Alice pays the transaction fee
+    feePayer: alicePublicKey,
+  });
+
+  // Transfer 0.01 SOL from Alice -> Bob
+  transaction.add(SystemProgram.transfer({
+    fromPubkey: alicePublicKey,
+    toPubkey: bobKeypair.publicKey,
+    lamports: 0.01 * LAMPORTS_PER_SOL
+  }));
+
+  // Transfer 1 token from Bob -> Alice
+  transaction.add(createTransferCheckedInstruction(
+    bobTokenAddress, // source
+    tokenAddress, // mint
+    aliceTokenAccount.address, // destination
+    bobKeypair.publicKey, // owner of source account
+    1 * (10 ** tokenMint.decimals), // amount to transfer
+    tokenMint.decimals, // decimals of token
+  ));
+
+  // Partial sign as Bob
+  transaction.partialSign(bobKeypair);
+
+  // Serialize the transaction and convert to base64 to return it
+  const serializedTransaction = transaction.serialize({
+    // We will need Alice to deserialize and sign the transaction
+    requireAllSignatures: false
+  });
+  const transactionBase64 = serializedTransaction.toString("base64");
+  return transactionBase64;
+
+  // The caller of this can convert it back to a transaction object:
+  const recoveredTransaction = Transaction.from(Buffer.from(transactionBase64, 'base64'));
+})();

--- a/code/offline-transactions/partial-sign/main.preview.en.ts
+++ b/code/offline-transactions/partial-sign/main.preview.en.ts
@@ -1,0 +1,20 @@
+// 1. Add an instruction to send the token from Bob to Alice
+transaction.add(createTransferCheckedInstruction(
+  bobTokenAddress, // source
+  tokenAddress, // mint
+  aliceTokenAccount.address, // destination
+  bobKeypair.publicKey, // owner of source account
+  1 * (10 ** tokenMint.decimals), // amount to transfer
+  tokenMint.decimals, // decimals of token
+));
+
+// 2. Bob partially signs the transaction
+transaction.partialSign(bobKeypair);
+
+// 3. Serialize the transaction without requiring all signatures
+const serializedTransaction = transaction.serialize({
+  requireAllSignatures: false
+});
+
+// 4. Alice can deserialize the transaction
+const recoveredTransaction = Transaction.from(Buffer.from(transactionBase64, 'base64'));

--- a/docs/references/offline-transactions.md
+++ b/docs/references/offline-transactions.md
@@ -62,6 +62,37 @@ anyone can broadcast it on the network.
   </SolanaCodeGroupItem>
 </SolanaCodeGroup>
 
+## Partial Sign Transaction
+
+When a transaction requires multiple signatures, you can partially sign it.
+The other signers can then sign and broadcast it on the network.
+
+Some examples of when this is useful:
+
+- Send an SPL token in return for payment
+- Sign a transaction so that you can later verify its authenticity
+- Call custom programs in a transaction that require your signature
+
+In this example Bob sends Alice an SPL token in return for her payment:
+
+<SolanaCodeGroup>
+  <SolanaCodeGroupItem title="TS" active>
+
+  <template v-slot:default>
+
+@[code](@/code/offline-transactions/partial-sign/main.en.ts)
+
+  </template>
+
+  <template v-slot:preview>
+
+@[code](@/code/offline-transactions/partial-sign/main.preview.en.ts)
+
+  </template>
+
+  </SolanaCodeGroupItem>
+</SolanaCodeGroup>
+
 ## Durable Nonce
 
 `RecentBlockhash` is an important value for a transaction. Your transaction will be rejected if you use an expired recent blockhash (after 150 blocks). You can use `durable nonce` to get a never expired recent blockhash. To trigger this mechanism, your transaction must


### PR DESCRIPTION
- Intended to address discord question: https://discord.com/channels/428295358100013066/517163444747894795/953743912437166150
- Modified from a NextJS example: https://github.com/mcintyre94/solana-partially-signed

- I've used public/private keys from other code examples
- The token address I've used is the one from https://spl-token-faucet.com

The code creates a transaction where:
- Alice sends Bob 0.01 SOL
- Bob sends Alice 1 token
- Bob partially signs the transaction
- The transaction is serialized + returned

New snippet: https://solana-cookbook-git-fork-mcintyre94-token-tx-pa-b4aeb7-cookbook.vercel.app/references/offline-transactions.html#partial-sign-transaction