### PR TITLE
Fixes Error: "Transaction leaves an account with a lower balance than rent-exempt minimum"

### DIFF
--- a/code/basic-transactions/sending-sol/sending-sol.adapter.en.tsx
+++ b/code/basic-transactions/sending-sol/sending-sol.adapter.en.tsx
@@ -14,7 +14,7 @@ export const SendTenLamportToRandomAddress: FC = () => {
       SystemProgram.transfer({
         fromPubkey: publicKey,
         toPubkey: Keypair.generate().publicKey,
-        lamports: 10,
+        lamports: 1_000_000,
       })
     );
 

--- a/code/basic-transactions/sending-sol/sending-sol.adapter.preview.en.tsx
+++ b/code/basic-transactions/sending-sol/sending-sol.adapter.preview.en.tsx
@@ -2,7 +2,7 @@ const transaction = new Transaction().add(
   SystemProgram.transfer({
     fromPubkey: publicKey,
     toPubkey: Keypair.generate().publicKey,
-    lamports: 10,
+    lamports: 1_000_000,
   })
 );
 

--- a/code/basic-transactions/sending-sol/sending-sol.en.py
+++ b/code/basic-transactions/sending-sol/sending-sol.en.py
@@ -10,14 +10,14 @@ client: Client = Client("https://api.devnet.solana.com")
 sender = Keypair.generate()
 receiver = Keypair.generate()
 
-airdrop = client.request_airdrop(sender.public_key, LAMPORT_PER_SOL)
+airdrop = client.request_airdrop(sender.public_key, 1 * LAMPORT_PER_SOL)
 airdrop_signature = airdrop["result"]
 client.confirm_transaction(airdrop_signature)
 
 transaction = Transaction().add(transfer(TransferParams(
     from_pubkey=sender.public_key,
     to_pubkey=receiver.public_key,
-    lamports=10)
+    lamports=1_000_000)
 ))
 
 client.send_transaction(transaction, sender)

--- a/code/basic-transactions/sending-sol/sending-sol.en.rs
+++ b/code/basic-transactions/sending-sol/sending-sol.en.rs
@@ -12,7 +12,7 @@ fn main() {
     let to = Keypair::new();
     let topubkey = Signer::pubkey(&to);
 
-    let lamports_to_send = 69;
+    let lamports_to_send = 1_000_000;
 
     let rpc_url = String::from("https://api.devnet.solana.com");
     let connection = RpcClient::new_with_commitment(rpc_url, CommitmentConfig::confirmed());

--- a/code/basic-transactions/sending-sol/sending-sol.en.sh
+++ b/code/basic-transactions/sending-sol/sending-sol.en.sh
@@ -1,1 +1,1 @@
-solana transfer --from <KEYPAIR> <RECIPIENT_ACCOUNT_ADDRESS> 0.5 --allow-unfunded-recipient --url https://api.devnet.solana.com --fee-payer <KEYPAIR>
+solana transfer --from <KEYPAIR> <RECIPIENT_ACCOUNT_ADDRESS> 0.001 --allow-unfunded-recipient --url https://api.devnet.solana.com --fee-payer <KEYPAIR>

--- a/code/basic-transactions/sending-sol/sending-sol.en.ts
+++ b/code/basic-transactions/sending-sol/sending-sol.en.ts
@@ -23,7 +23,7 @@ import {
 
   await connection.confirmTransaction(airdropSignature);
 
-  const lamportsToSend = 10;
+  const lamportsToSend = 1_000_000;
 
   const transferTransaction = new Transaction()
     .add(SystemProgram.transfer({

--- a/code/basic-transactions/sending-sol/sending-sol.preview.en.py
+++ b/code/basic-transactions/sending-sol/sending-sol.preview.en.py
@@ -1,7 +1,7 @@
 transaction = Transaction().add(transfer(TransferParams(
     from_pubkey=sender.public_key,
     to_pubkey=receiver.public_key,
-    lamports=10)
+    lamports=1_000_000)
 ))
 
 client.send_transaction(transaction, sender)


### PR DESCRIPTION
Since feature _BkFDxiJQWZXGTZaJQxH7wVEHkAmwCgSEVkrvswFfRJPD_, new accounts are required to be rent-exempt. 

```bash
solana rent 0
```
```
Rent-exempt minimum: 0.00089088 SOL
```

**Error:**
- https://github.com/solana-labs/solana/blob/f81c5df1f02b0e41f3e5dd3d236a34818cc40a5a/sdk/src/transaction/error.rs

**Related issues:**
- https://github.com/solana-labs/dapp-scaffold/issues/173
- https://github.com/solana-labs/dapp-scaffold/issues/178



@jacobcreech what do you think about adding this extra quote:
_"If you are sending SOL to an uninitialized account, for example, a new address without an account. Make sure to send an amount above the rent-exempt minimum. The minimum amount to be rent exempt can be found using the CLI with `solana rent 0`"_
