### PR TITLE
update: replace deprecated requestAirdrop method

### DIFF
--- a/code/local-development/airdropping-sol/airdropping-sol.preview.en.ts
+++ b/code/local-development/airdropping-sol/airdropping-sol.preview.en.ts
@@ -1,6 +1,27 @@
-const airdropSignature = await connection.requestAirdrop(
-  keypair.publicKey,
-  LAMPORTS_PER_SOL
-);
+const airdropTestSOL = async() => {
+  try {
+    const connection = new Connection(clusterApiUrl("devnet"), "confirmed");
+    const airdropSignature = await connection.requestAirdrop)
+      keypair.publicKey,
+      LAMPORTS_PER_SOL
+    );
+    
+    const latestBlockHash = await connection.getLatestBlockhash();
+    
+    await connection.confirmTransaction({
+        blockhash: latestBlockHash.blockhash,
+        lastValidBlockHeight: latestBlockHash.lastValidBlockHeight,
+        signature: airdropSignature,
+    });
+  } catch (error) {
+    console.log(error);
+  };
+};
 
-await connection.confirmTransaction(airdropSignature);
+// The following code blocks are deprecated.
+// const airdropSignature = await connection.requestAirdrop(
+//   keypair.publicKey,
+//   LAMPORTS_PER_SOL
+// );
+
+// await connection.confirmTransaction(airdropSignature);


### PR DESCRIPTION
- The new `requestAirdrop` method has been implemented the `BlockheightBasedTransactionConfirmationStrategy`, though the fact that the deprecated method has now been working well yet.
- The type expects to receive the arguments of `blockhash` as string and `lastValidBlockHeight` as number.
```typescript
confirmTransaction(
  strategy: BlockheightBasedTransactionConfirmationStrategy,
  commitment?: Commitment,
): Promise<RpcResponseAndContext<SignatureResult>>;
```
- The strategy looks like the following blocks.
```typescript
type BlockheightBasedTransactionConfirmationStrategy = {
    signature: string;
} & Readonly<{
    blockhash: string;
    lastValidBlockHeight: number;
}>
```