### PR TITLE
Clarify language around token accounts

### DIFF
--- a/docs/references/token.md
+++ b/docs/references/token.md
@@ -80,10 +80,10 @@ create the initial supply.
   </SolanaCodeGroupItem>
 </SolanaCodeGroup>
 
-## How to get a token mint
+## How to get mint information from a mint account
 
 In order to get the current supply, authority, or decimals a token has,
-you will need to get the account info for the token mint.
+you will need to get the account info for the mint accont.
 
 <SolanaCodeGroup>
   <SolanaCodeGroupItem title="TS" active>
@@ -105,7 +105,7 @@ you will need to get the account info for the token mint.
 
 ## How to create a token account
 
-A token account is required in order to hold tokens. Every token mint
+A token account is required in order to hold tokens. Every mint account
 has a different token account associated with it.
 
 Associated Token Accounts are deterministicly created
@@ -130,7 +130,7 @@ of managing token accounts.
   </SolanaCodeGroupItem>
 </SolanaCodeGroup>
 
-## How to get a Token Account
+## How to get information from a Token Account
 
 Every token account has information on the token such as the owner,
 mint, amount(balance), and decimals.


### PR DESCRIPTION
## Summary of changes

1. Rename 'How to get a token mint' to 'How to get mint information from a mint account'

Per the docstrings for `getMint()` this function gets information from a mint account. The older title makes it seem like `getMint()` could return a mint account which is not correct.

2.  Swap 'you will need to get the account info for the token mint' for 'you will need to get the account info for the mint account' because `getMint()` takes a mint account as a parameter. We should use 'mint account' here as it's consistent with the rest of the docs, and 'mint account' is what the `getMint()` ocstring uses, and 'token mint' could be interpreted as the 'token account' which would be incorrect.

3.  Swap:

> Every token mint has a different token account associated with it.

> Every mint account has a different token account associated with it.

'mint' is usually used as a verb so it's difficult to understand the older sentence. I think the intention is  to say that 'every mint account has a different token account associated with it' - is that correct?

4. Swap

> How to get a Token Account

with

> How to get information from a Token Account

Likewise `getAccount()` doesn't actually retrieve the token account - instead, you provide the token account and `getAccount()` (which probably needs a better name) provides token information.




