### PR TITLE
Clarify that tokens are minted into user's token accounts

### DIFF
--- a/docs/references/token.md
+++ b/docs/references/token.md
@@ -59,8 +59,7 @@ be used, which you can find below based on your language.
 ## How to create a new Token
 
 Creating tokens is done by creating what is called a "mint account".
-This mint account is later used to mint tokens to a token account and
-create the initial supply.
+This mint account is later used to mint tokens to a user's token account.
 
 <SolanaCodeGroup>
   <SolanaCodeGroupItem title="TS" active>
@@ -105,8 +104,9 @@ you will need to get the account info for the token mint.
 
 ## How to create a token account
 
-A token account is required in order to hold tokens. Every token mint
-has a different token account associated with it.
+A token account is required for a user to hold tokens. 
+
+A user will have at least one token account for every type of token they own.  
 
 Associated Token Accounts are deterministicly created
 accounts for every keypair. ATAs are the recommended method


### PR DESCRIPTION
Heya! I'm contributing here because my original impression from reading this doc was a little misleading. When I read 

"Every token mint has a different token account associated with it."

I thought this meant that FooToken's mint account would mint to FooToken's token account, and then be transferred to some user's FooToken token account.

From what I've been told, that's incorrect - [talking with others in Solana Stack Exchange](https://solana.stackexchange.com/questions/849/are-new-spl-tokens-typically-transferred-from-a-mints-token-account-to-a-users), it seems that a token is minted directly to a user's token account. FooToken mint account, mints token to Joe Smith's FooToken Token Account.

Is that correct? If so I've made some changes to clarify this, which should help clarify things for other people learning Solana.