### PR TITLE
Update the React Native integration docs for these modern times

### DIFF
--- a/docs/integrations/react-native.md
+++ b/docs/integrations/react-native.md
@@ -168,9 +168,9 @@ Lastly, in the template (or `render function`) add the following markup:
 <Button title="New Keypair" onPress={randomKeypair} />
 ```
 
-### Install cocoapods
+### [iOS only] Install cocoapods
 
-In order for our polyfills to work, we need to install the `cocoapods`.
+In order for our polyfills to be autolinked on iOS, we need to install the `cocoapods`.
 
 ```shell
 cd ios && pod install
@@ -178,13 +178,14 @@ cd ios && pod install
 
 ### Start application 
 
-Once we finished all the above, we can start our application
+Once we finished all the above, we can start our application in the Android or iOS simulator.
 
 ```shell
-npx react-native run-ios
+yarn android
+yarn ios
 ```
 
-If all went well, you should see a React Native app being started in your iOS simulator that retrieves the version of the Solana Devnet.
+If all went well, you should see a React Native app being started in your simulator that retrieves the version of the Solana Devnet.
 
 ## Solana DApp Scaffold for React Native
 

--- a/docs/integrations/react-native.md
+++ b/docs/integrations/react-native.md
@@ -65,10 +65,14 @@ In the meantime, follow the [&ldquo;Adding TypeScript to an Existing Project&rdq
 
 ### Install dependencies
 
-Next, we install the dependencies. We install the Solana SDK, and in addition we install a package to patch the `metro` configuration, and two polyfills that patch the React Native environment. 
+Next, we install the dependencies. The Solana JavaScript SDK, a package to patch the React Native build system (Metro), a secure random number generator, and a fix to patch React Native's missing `URL` class.
 
 ```shell
-yarn add @solana/web3.js metro-config react-native-get-random-values react-native-url-polyfill
+yarn add \
+  @solana/web3.js \
+  metro-config \
+  react-native-get-random-values \
+  react-native-url-polyfill
 ```
 
 ### Update `index.js`

--- a/docs/integrations/react-native.md
+++ b/docs/integrations/react-native.md
@@ -75,6 +75,22 @@ yarn add \
   react-native-url-polyfill
 ```
 
+### Patch Babel to use the Hermes transforms
+
+As of August 2022 the template from which new React Native apps are made enables the Hermes JavaScript engine by default but not the Hermes code transforms. Enable them by making the following change to `babel.config.js`:
+
+```diff
+  module.exports = {
+-   presets: ['module:metro-react-native-babel-preset'],
++   presets: [
++     [
++       'module:metro-react-native-babel-preset',
++       {unstable_transformProfile: 'hermes-stable'},
++     ],
++   ],
+};
+```
+
 ### Update `index.js`
 
 To load the polyfills, we open the file `index.js` in the root of the project and add the following two lines to the top of the file:

--- a/docs/integrations/react-native.md
+++ b/docs/integrations/react-native.md
@@ -53,7 +53,7 @@ If you already have an existing app, skip to [installing the dependencies](#inst
 We start a new React Native application that uses TypeScript, then `cd` into the project directory, where we will execute the rest of the commands.
 
 ```shell
-npx react-native init SolanaReactNative --template react-native-template-typescript
+npx react-native@"0.70.0-rc.4" init SolanaReactNative --version 0.70.0-rc.4
 cd SolanaReactNative
 ```
 

--- a/docs/integrations/react-native.md
+++ b/docs/integrations/react-native.md
@@ -141,20 +141,18 @@ In this example, we set up a connection to Solana Devnet and when the components
 Additionally, this example shows how to generate and store a keypair.
 
 ```typescript
-const conn = new Connection(clusterApiUrl('devnet'));
-const [version, setVersion] = useState<any>('');
 const [keypair, setKeypair] = useState<Keypair>(() => Keypair.generate());
-
 const randomKeypair = () => {
   setKeypair(() => Keypair.generate());
 };
 
+const [version, setVersion] = useState<any>('');
 useEffect(() => {
-  if (version) {
-    return;
-  }
-  conn.getVersion().then(r => setVersion(r));
-}, [version, setVersion]);
+  const conn = new Connection(clusterApiUrl('devnet'));
+  conn.getVersion().then(r => {
+    setVersion(r);
+  });
+}, []);
 ```
 
 Lastly, in the template (or `render function`) add the following markup:

--- a/docs/integrations/react-native.md
+++ b/docs/integrations/react-native.md
@@ -57,6 +57,12 @@ npx react-native@"0.70.0-rc.4" init SolanaReactNative --version 0.70.0-rc.4
 cd SolanaReactNative
 ```
 
+::: warning
+We _highly_ recommend using TypeScript in your React Native projects. Usually we would recommend calling `npx react-native init` with the `--template react-native-template-typescript` command, but as of August 2022 the TypeScript template has not been updated to React Native 0.70.
+
+In the meantime, follow the [&ldquo;Adding TypeScript to an Existing Project&rdquo; docs](https://reactnative.dev/docs/typescript#adding-typescript-to-an-existing-project) to add TypeScript to the new project you just created above.
+:::
+
 ### Install dependencies
 
 Next, we install the dependencies. We install the Solana SDK, and in addition we install a package to patch the `metro` configuration, and two polyfills that patch the React Native environment. 

--- a/docs/integrations/react-native.md
+++ b/docs/integrations/react-native.md
@@ -192,7 +192,7 @@ If all went well, you should see a React Native app being started in your simula
 If you want to hit the ground running, you can download the [Solana DApp Scaffold for React Native](https://github.com/solana-developers/dapp-scaffold-react-native).
 
 
-## Common issues when using @solana/web3.js in a React Native app
+## Common issues when using crypto libraries in a React Native app
 
 ### Error: While trying to resolve module superstruct from file
 


### PR DESCRIPTION
Folks are starting to [rightfully complain](https://solana.stackexchange.com/questions/2275/error-while-generating-a-build-in-react-native-using-solana-web3-js) that the cookbook directions for React Native no longer work with modern versions of `@solana/web3.js`. This PR updates that recipe.

Essentially, the new directions instruct people to use a version of React Native >=v0.70. An explanation of why can be found here: https://twitter.com/steveluscher/status/1565232091260157952