### PR TITLE
Revise section to show how to use the new ComputeBudgetProgram

### DIFF
--- a/code/basic-transactions/compute-budget/computeBudget.en.rs
+++ b/code/basic-transactions/compute-budget/computeBudget.en.rs
@@ -10,8 +10,7 @@ use solana_sdk::{
     transaction::Transaction,
 };
 
-/// Submits the program instruction as per the
-/// instruction definition
+/// Submits the program instruction as per the instruction definition
 fn submit_transaction(
     rpc_client: &RpcClient,
     wallet_signer: &dyn Signer,
@@ -43,8 +42,10 @@ fn send_instructions_demo(
     let txn = submit_transaction(
         &connection,
         &wallet_signer,
-        // Array of instructions: 0: Increase Budget, 1: Do something, 2: Do something else
-        [ComputeBudgetInstruction::request_units(400_000u32),
+        // Array of instructions: 0: Set Compute Unit Limt, 1: Set Prioritization Fee, 
+        // 2: Do something, 3: Do something else
+        [ComputeBudgetInstruction::set_compute_unit_limit(1_000_000u32),
+        ComputeBudgetInstruction::set_compute_unit_price(1u32),
         Instruction::new_with_borsh(PROG_KEY, &0u8, accounts.to_vec()),
         Instruction::new_with_borsh(PROG_KEY, &0u8, accounts.to_vec())].to_vec(),
     )?;

--- a/code/basic-transactions/compute-budget/computeBudget.en.tsx
+++ b/code/basic-transactions/compute-budget/computeBudget.en.tsx
@@ -22,12 +22,18 @@ import {
 
   await connection.confirmTransaction(airdropSignature);
 
-  const additionalComputeBudgetInstruction = ComputeBudgetProgram.requestUnits({
-    units: 400000,
-    additionalFee: 0,
+  const modifyComputeUnits = ComputeBudgetProgram.setComputeUnitLimit({ 
+    units: 1000000 
   });
+
+  const addPriorityFee = ComputeBudgetProgram.setComputeUnitPrice({ 
+    microLamports: 1 
+  });
+
+  // Total fee will be 5,001 Lamports for 1M CU
   const transaction = new Transaction()
-    .add(additionalComputeBudgetInstruction)
+    .add(modifyComputeUnits)
+    .add(addPriorityFee)
     .add(
       SystemProgram.transfer({
         fromPubkey: payer.publicKey,

--- a/code/basic-transactions/compute-budget/computeBudget.preview.en.rs
+++ b/code/basic-transactions/compute-budget/computeBudget.preview.en.rs
@@ -1,8 +1,10 @@
 let txn = submit_transaction(
   &connection,
   &wallet_signer,
-  // Array of instructions: 0: Increase Budget, 1: Do something, 2: Do something else
-  [ComputeBudgetInstruction::request_units(400_000u32),
+  // Array of instructions: 0: Set Compute Unit Limt, 1: Set Prioritization Fee, 
+  // 2: Do something, 3: Do something else
+  [ComputeBudgetInstruction::set_compute_unit_limit(1_000_000u32),
+  ComputeBudgetInstruction::set_compute_unit_price(1u32),
   Instruction::new_with_borsh(PROG_KEY, &0u8, accounts.to_vec()),
   Instruction::new_with_borsh(PROG_KEY, &0u8, accounts.to_vec())].to_vec(),
 )?;

--- a/code/basic-transactions/compute-budget/computeBudget.preview.en.tsx
+++ b/code/basic-transactions/compute-budget/computeBudget.preview.en.tsx
@@ -1,10 +1,15 @@
-const additionalComputeBudgetInstruction = ComputeBudgetProgram.requestUnits({
-  units: 400000,
-  additionalFee: 0,
+const modifyComputeUnits = ComputeBudgetProgram.setComputeUnitLimit({ 
+  units: 1000000 
 });
+
+const addPriorityFee = ComputeBudgetProgram.setComputeUnitPrice({ 
+  microLamports: 1 
+});
+
 const transaction = new Transaction()
-  .add(additionalComputeBudgetInstruction)
-  .add(
+.add(modifyComputeUnits)
+.add(addPriorityFee)
+.add(
     SystemProgram.transfer({
       fromPubkey: payer.publicKey,
       toPubkey: toAccount,

--- a/code/basic-transactions/compute-budget/log_output.txt
+++ b/code/basic-transactions/compute-budget/log_output.txt
@@ -1,9 +1,5 @@
-[ 1] Program PWDnx8LkjJUn9bAVzG6Fp6BuvB41x7DkBZdo9YLMGcc invoke [1]
-[ 2] Program log: process_instruction: PWDnx8LkjJUn9bAVzG6Fp6BuvB41x7DkBZdo9YLMGcc: 0 accounts, data=[0]
-[ 3] Program PWDnx8LkjJUn9bAVzG6Fp6BuvB41x7DkBZdo9YLMGcc consumed 12843 of 400000 compute units
-[ 4] Program PWDnx8LkjJUn9bAVzG6Fp6BuvB41x7DkBZdo9YLMGcc success
-[ 5]
-[ 6] Program PWDnx8LkjJUn9bAVzG6Fp6BuvB41x7DkBZdo9YLMGcc invoke [1]
-[ 7] Program log: process_instruction: PWDnx8LkjJUn9bAVzG6Fp6BuvB41x7DkBZdo9YLMGcc: 0 accounts, data=[1]
-[ 8] Program PWDnx8LkjJUn9bAVzG6Fp6BuvB41x7DkBZdo9YLMGcc consumed 12843 of 387157 compute units
-[ 9] Program PWDnx8LkjJUn9bAVzG6Fp6BuvB41x7DkBZdo9YLMGcc success
+[ 1] Program ComputeBudget111111111111111111111111111111 invoke [1]
+[ 2] Program ComputeBudget111111111111111111111111111111 success
+[ 3]
+[ 4] Program ComputeBudget111111111111111111111111111111 invoke [1]
+[ 5] Program ComputeBudget111111111111111111111111111111 success

--- a/docs/references/basic-transactions.md
+++ b/docs/references/basic-transactions.md
@@ -267,16 +267,31 @@ manually `MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr`.
 
 </SolanaCodeGroup>
 
-## How to change compute budget for a transaction
+## How to change compute budget, fee, &amp; priority for a transaction
+Transaction (TX) priority is transaction fee divided by compute units (CU), e.g. 
+fee/CU. By default the compute budget is 1.4M CU and the Base Fee is 5,000 
+Lamports. A microLamport is 0.000001 Lamports.
 
-Compute budget for a single transaction can be changed by adding an instruction
-call to the Compute Budget Program. By default the compute budget is set the product 
-of 200k compute units * number of instructions, with a max of 1.4M compute units. 
-The less compute you use, the less the transaction costs.
+The total compute budget or fee for a single TX can be changed by adding 
+instructions from the ComputeBudgetProgram. 
 
-**Note**: To change the compute budget for a transaction, you must make the 
-one of the first three instructions of the transaction the instruction that 
-sets the budget.
+Use `ComputeBudgetProgram.setComputeUnitLimit({ units: number })` to set
+the new compute budget. The value provided will replace the default value. 
+Transactions should request the minimum amount of CU required for 
+execution to maximize throughput, minimize fees, or increase priority.
+
+Pro Tip: You can increase the priority (fee/CU) of small TXs by reducing the CU 
+budget without adding an extra fee.
+
+`ComputeBudgetProgram.setComputeUnitPrice({ microLamports: number })` 
+will increase the transaction fee above the base fee (5,000 Lamports). The value
+provided in microLamports will be multiplied by the CU budget to determine the 
+Prioritization Fee in Lamports. For example, if your CU budget is 1M CU, and you 
+add 1 microLamport/CU, the Prioritization Fee will be 1 Lamport (1M * 0.000001). 
+The total fee will then be 5001 Lamports.
+
+**Note**: You must include the ComputeBudgetProgram instructions in the first 
+three instructions of the transaction.
 
 <SolanaCodeGroup>
   <SolanaCodeGroupItem title="TS" active>
@@ -310,7 +325,7 @@ sets the budget.
 
 </SolanaCodeGroup>
 
-Program Logs Example:
+Program Logs Example ( [Explorer](https://explorer.solana.com/tx/2mNPXeoy3kFxo12L8avsEoep65S4Ehvw2sheduDrAXbmmNJwTtXNmUrb5MM3s15eki2MWSQrwyKGAUQFZ9wAGo9K/) ):
 
 <CodeGroup>
   <CodeGroupItem title="Log Output">


### PR DESCRIPTION
I updated this section to show how to use the new `ComputeBudgetProgram.setComputeUnitLimit` & `ComputeBudgetProgram.setComputeUnitPrice` instructions. The previous version showed the deprecated method that will soon be removed.