### PR TITLE
refactor: use new, lightweight library for deriving keys from mnemonic

### DIFF
--- a/code/keypairs-and-wallets/mnemonic-to-keypair/from-bip44.ts
+++ b/code/keypairs-and-wallets/mnemonic-to-keypair/from-bip44.ts
@@ -1,16 +1,15 @@
 import { Keypair } from "@solana/web3.js";
-import { derivePath } from "ed25519-hd-key";
+import { HDKey } from "micro-ed25519-hdkey";
 import * as bip39 from "bip39";
 
 (async () => {
   const mnemonic =
     "neither lonely flavor argue grass remind eye tag avocado spot unusual intact";
   const seed = bip39.mnemonicToSeedSync(mnemonic, ""); // (mnemonic, password)
+  const hd = HDKey.fromMasterSeed(seed.toString("hex"));
   for (let i = 0; i < 10; i++) {
     const path = `m/44'/501'/${i}'/0'`;
-    const keypair = Keypair.fromSeed(
-      derivePath(path, seed.toString("hex")).key
-    );
+    const keypair = Keypair.fromSeed(hd.derive(path).privateKey);
     console.log(`${path} => ${keypair.publicKey.toBase58()}`);
   }
 })();


### PR DESCRIPTION
This patch updates the guide on how to derive private keys from mnemonic.

It uses the package [micro-ed25519-hdkey](https://github.com/paulmillr/micro-ed25519-hdkey) which is a new package that replaces `ed25519-hd-key`.  

The big benefit over using this new version is that you don't need to add polyfills (like `stream-browserify`, etc) and a custom webpack config to make it work, it works in browsers directly! 