### PR TITLE
fix: update confirmTransaction method usage in airdropping-sol

### DIFF
--- a/code/local-development/airdropping-sol/airdropping-sol.en.ts
+++ b/code/local-development/airdropping-sol/airdropping-sol.en.ts
@@ -5,10 +5,14 @@ import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
 
   const connection = new Connection("http://127.0.0.1:8899", "confirmed");
 
-  const airdropSignature = await connection.requestAirdrop(
+  const signature = await connection.requestAirdrop(
     keypair.publicKey,
     LAMPORTS_PER_SOL
   );
-
-  await connection.confirmTransaction(airdropSignature);
+  const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash();
+  await connection.confirmTransaction({
+      blockhash,
+      lastValidBlockHeight,
+      signature
+    });
 })();


### PR DESCRIPTION
confirmTransaction in the airdropping-sol TS code block is deprecated. Updated it to the latest confirmTransaction method usage. 