### PR TITLE
fix broken links in vTX guide

### DIFF
--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -66,6 +66,7 @@ export default defineUserConfig<DefaultThemeOptions>({
                 "/guides/retrying-transactions.md",
                 "/guides/debugging-solana-programs.md",
                 "/guides/feature-parity-testing.md",
+                "/guides/versioned-transactions.md"
               ],
             },
             {


### PR DESCRIPTION
* Add vTX guide path to `docs/.vuepress/config.ts`
* fix broken image links in vTX guide
* fix some minor formatting issues in vTX guide