### PR TITLE
fix: "Cannot read properties of undefined" error

### DIFF
--- a/code/basic-transactions/sending-spl-token/sending-spl-token.en.ts
+++ b/code/basic-transactions/sending-spl-token/sending-spl-token.en.ts
@@ -1,65 +1,80 @@
-const web3 = require("@solana/web3.js");
-const splToken = require("@solana/spl-token");
+import {
+  Connection,
+  clusterApiUrl,
+  Keypair,
+  LAMPORTS_PER_SOL,
+  Transaction,
+  sendAndConfirmTransaction,
+} from "@solana/web3.js";
+import {
+  createMint,
+  getOrCreateAssociatedTokenAccount,
+  mintTo,
+  createTransferInstruction,
+} from "@solana/spl-token";
 
 (async () => {
   // Connect to cluster
-  const connection = new web3.Connection(
-    web3.clusterApiUrl("devnet"),
-    "confirmed"
-  );
+  const connection = new Connection(clusterApiUrl("devnet"), "confirmed");
 
   // Generate a new wallet keypair and airdrop SOL
-  const fromWallet = web3.Keypair.generate();
+  const fromWallet = Keypair.generate();
   const fromAirdropSignature = await connection.requestAirdrop(
     fromWallet.publicKey,
-    web3.LAMPORTS_PER_SOL
+    LAMPORTS_PER_SOL
   );
   // Wait for airdrop confirmation
   await connection.confirmTransaction(fromAirdropSignature);
 
   // Generate a new wallet to receive newly minted token
-  const toWallet = web3.Keypair.generate();
+  const toWallet = Keypair.generate();
 
   // Create new token mint
-  const mint = await splToken.createMint(
+  const mint = await createMint(
     connection,
     fromWallet,
     fromWallet.publicKey,
     null,
-    9,
-    splToken.TOKEN_PROGRAM_ID
+    9
   );
 
   // Get the token account of the fromWallet Solana address, if it does not exist, create it
-  const fromTokenAccount = await mint.getOrCreateAssociatedAccountInfo(
+  const fromTokenAccount = await getOrCreateAssociatedTokenAccount(
+    connection,
+    fromWallet,
+    mint,
     fromWallet.publicKey
   );
 
   //get the token account of the toWallet Solana address, if it does not exist, create it
-  const toTokenAccount = await mint.getOrCreateAssociatedAccountInfo(
+  const toTokenAccount = await getOrCreateAssociatedTokenAccount(
+    connection,
+    fromWallet,
+    mint,
     toWallet.publicKey
   );
 
   // Minting 1 new token to the "fromTokenAccount" account we just returned/created
-  await mint.mintTo(
+  await mintTo(
+    connection,
+    fromWallet,
+    mint,
     fromTokenAccount.address,
     fromWallet.publicKey,
-    [],
-    1000000000 // it's 1 token, but in lamports
+    1000000000, // it's 1 token, but in lamports
+    []
   );
 
   // Add token transfer instructions to transaction
-  const transaction = new web3.Transaction().add(
-    splToken.createTransferInstruction(
-      splToken.TOKEN_PROGRAM_ID,
+  const transaction = new Transaction().add(
+    createTransferInstruction(
       fromTokenAccount.address,
       toTokenAccount.address,
       fromWallet.publicKey,
-      [],
       1
     )
   );
 
   // Sign transaction, broadcast, and confirm
-  await web3.sendAndConfirmTransaction(connection, transaction, [fromWallet]);
+  await sendAndConfirmTransaction(connection, transaction, [fromWallet]);
 })();


### PR DESCRIPTION
# Description
## Issue
I got following error when I run example codes.
```
      const key = signer.publicKey.toString();
                                   ^
TypeError: Cannot read properties of undefined (reading 'toString')
    at Transaction.apply [as sign]
```

## Cause
@solana/spl-token changed some functions/methods.
Details: https://stackoverflow.com/a/71496672

## Solution
I update some codes for latest versions(@solana/spl-token v0.3.8 - 6/1/2023).

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [  ] New feature (non-breaking change which adds functionality)
- [  ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [  ] This change requires a documentation update