### PR TITLE
PDA max size is 10MB as of other accounts

### DIFF
--- a/docs/core-concepts/accounts.md
+++ b/docs/core-concepts/accounts.md
@@ -49,9 +49,9 @@ building block for developing on Solana.
 - Accounts are used to store data
 - Each account has a unique address
 - Accounts have a max size of 10MB (10 Mega Bytes)
-- PDA accounts have a max size of 10KB (10 Kilo Bytes)
+- PDA accounts have an initial max size of 10KB (10 Kilo Bytes)
+- Accounts size are fixed at creation time, but can be adjusted using [realloc](https://solanacookbook.com/references/programs.html#how-to-change-account-size) up to 10MB
 - PDA accounts can be used to sign on behalf of a program
-- Accounts size are fixed at creation time, but can be adjusted using [realloc](https://solanacookbook.com/references/programs.html#how-to-change-account-size)
 - Account data storage is paid with rent
 - Default account owner is the System Program
   :::

--- a/docs/references/programs.md
+++ b/docs/references/programs.md
@@ -150,8 +150,8 @@ The client side instruction, now only needs to pass the state and payer accounts
 
 ## How to change account size
 
-You can change a program owned account's size with the use 
-of `realloc`. `realloc` can resize an account up to 10KB.
+You can change an account's size with the use of `realloc`.
+`realloc` can resize an account in steps of 10KB up to 10MB of max size.
 When you use `realloc` to increase the size of an account,
 you must transfer lamports in order to keep that account
 rent-exempt.


### PR DESCRIPTION
I would like to fix a wrong definition of max sizes that are defined in the doc.
The Solana max size of an account is 10MB. The 10KB is max size that the runtime permits to `realloc` at one call (https://github.com/solana-labs/solana/blob/master/sdk/program/src/account_info.rs#L133). The PDA can be created in 10KB size but can be reallocated up to 10MB size as system accounts.