### PR TITLE
Update Deprecated Keypair Method in Solana Python SDK Examples

### DIFF
--- a/code/keypairs-and-wallets/keypair-from-secret/from-bs58.en.py
+++ b/code/keypairs-and-wallets/keypair-from-secret/from-bs58.en.py
@@ -1,5 +1,5 @@
-from solders.keypair import Keypair
+from solana.transaction import Keypair
 
 b58_string = "5MaiiCavjCmn9Hs1o3eznqDEhRwxo7pXiAYez7keQUviUkauRiTMD8DrESdrNjN8zd9mTmVhRvBJeg5vhyvgrAhG"
-keypair = Keypair.from_string(b58_string)
+keypair = Keypair.from_base58_string(b58_string)
 print("Created Keypair with Public Key: {}".format(keypair.pubkey()))

--- a/code/keypairs-and-wallets/keypair-from-secret/from-bs58.preview.en.py
+++ b/code/keypairs-and-wallets/keypair-from-secret/from-bs58.preview.en.py
@@ -1,2 +1,4 @@
+from solana.transaction import Keypair
+
 b58_string = "5MaiiCavjCmn9Hs1o3eznqDEhRwxo7pXiAYez7keQUviUkauRiTMD8DrESdrNjN8zd9mTmVhRvBJeg5vhyvgrAhG"
-keypair = Keypair.from_string(b58_string)
+keypair = Keypair.from_base58_string(b58_string)


### PR DESCRIPTION
This PR updates the Python SDK usage examples in the solana-cookbook to replace the deprecated `Keypair.from_string` method with the current `Keypair.from_base58_string`.

The `from_string` method is no longer supported in the latest versions of the Solana Python SDK, and its usage can lead to errors for users. This update ensures the examples in the documentation are up to date and functional.