### PR TITLE
Remove redundant library from all.en.ts

### DIFF
--- a/code/token/get-token-account-by-owner/all.en.ts
+++ b/code/token/get-token-account-by-owner/all.en.ts
@@ -1,6 +1,5 @@
 import { clusterApiUrl, Connection, PublicKey } from "@solana/web3.js";
 import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
-import * as bs58 from "bs58";
 
 (async () => {
   // connection


### PR DESCRIPTION
Removed redundant line

`import * as bs58 from "bs58";`

as `bs58` is not used in the code