### PR TITLE
Fix order of setting provider for wallet connection

### DIFF
--- a/code/keypairs-and-wallets/connect-to-wallet/connect-to-wallet-react.en.tsx
+++ b/code/keypairs-and-wallets/connect-to-wallet/connect-to-wallet-react.en.tsx
@@ -37,9 +37,9 @@ export const Web3Provider: FC<PropsWithChildren<{}>> = ({ children }) => {
 
   return (
     <ConnectionProvider endpoint={endpoint}>
-      <WalletModalProvider>
-        <WalletProvider wallets={wallets}>{children}</WalletProvider>
-      </WalletModalProvider>
+      <WalletProvider wallets={wallets}>
+        <WalletModalProvider>{children}</WalletModalProvider>
+      </WalletProvider>
     </ConnectionProvider>
   );
 };


### PR DESCRIPTION
The following error occurred when I made the wallet connection with reference to the Cookbook.

```
Error: You have tried to read "wallets" on a WalletContext without providing one. Make sure to render a WalletProvider as an ancestor of the component that uses WalletContext.
```

`WalletModalProvider` depends on `WalletProvider`, which seems to be in the wrong order.